### PR TITLE
Update parameter.py

### DIFF
--- a/toolbox_runner/parameter.py
+++ b/toolbox_runner/parameter.py
@@ -64,6 +64,7 @@ def _parse_param(key: str, val: str, param_config: dict):
 
 
 def parse_parameter() -> dict:
+    print("YOU ARE USING AN OLD VERSION OF parse_parameter. PLEASE USE get_parameter FROM the json2args package.")
     # load the parameter file
     with open(get_env()['param_file']) as f:
         p = json.load(f)


### PR DESCRIPTION
This prints a warning to the console, when `parse_parameters` from `toolbox_runner` is used. 
From now on, the `json2args` package should be used. 

With one of the next versions, the code should actually throw a FutureWarning