### PR TITLE
Automatically pull tool images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 pandas
 blinker
 networkx
+PyGithub


### PR DESCRIPTION
The PR solves a few things in the `run.py`:

* The `list_tools` now accepts a list of prefixes #1 (ie. `tbr_` for local build and `ghcr.io/vforwater/tbr_` for downloaded ones)
* Added `get_remote_image_list` to download the curated list `./tool-list.txt` 
* Added `update_tools` to pull anything from tool-list no matter what in the specified versions

@AlexDo1 can you remove your local tool images and run the update_tools function? 