### PR TITLE
bugfix for untagged images

### DIFF
--- a/toolbox_runner/run.py
+++ b/toolbox_runner/run.py
@@ -36,6 +36,9 @@ def list_tools(prefix: Union[str, List[str]] = 'tbr_', as_dict: bool = False) ->
     # container for tools
     tools = []
     for image in images:
+        # check if there are tags at first. toolbox-runner can't work without tags
+        if len(image.tags) == 0:
+            continue
         # get the first repo and tag combination
         repo, tag = image.tags[0].split(':')
         


### PR DESCRIPTION
If there are untagged images present, the `list_tools`function will fail. This fix will ignore untagged images