### PR TITLE
file can also be a folder

### DIFF
--- a/toolbox_runner/tool.py
+++ b/toolbox_runner/tool.py
@@ -306,9 +306,15 @@ class Tool:
             # Copy any file source
             elif isinstance(value, str):
                 if self.parameters[key]['type'] == 'file':
-                    fname = f"{key}{os.path.splitext(value)[1]}"
-                    shutil.copy(value, os.path.join(path, fname))
-                    value = f"/in/{fname}"
+                    # check if file is actually a folder (no file extension)
+                    if not os.path.splitext(value)[1]:
+                        dirname = os.path.basename(os.path.normpath(value))
+                        shutil.copytree(value, os.path.join(path, dirname), dirs_exist_ok=False)
+                        value = f"/in/{dirname}"
+                    else:
+                        fname = f"{key}{os.path.splitext(value)[1]}"
+                        shutil.copy(value, os.path.join(path, fname))
+                        value = f"/in/{fname}"
 
             # add
             params[key] = value


### PR DESCRIPTION
With this PR, parameters of type `file` can also be a folder.  
`tool-runner` automatically recognizes, if a path is a folder and not a file (by checking if a file extension exists). If no file extension exists, the entire folder is copied into the tool container.  
This is only a proposal, we can of course implement this in another way (e.g. with a new parameter type `folder`). I just needed this for a tool in the `cdo_tool`.