### PR TITLE
New parameter type `asset`

### DIFF
--- a/toolbox_runner/tool.py
+++ b/toolbox_runner/tool.py
@@ -303,13 +303,29 @@ class Tool:
                         json.dump(value, f, indent=4)
                     value = f"/in/{fname}"
             
-            # Copy any file source
+            # Copy any file source and assets
             elif isinstance(value, str):
                 if self.parameters[key]['type'] == 'file':
                     fname = f"{key}{os.path.splitext(value)[1]}"
                     shutil.copy(value, os.path.join(path, fname))
                     value = f"/in/{fname}"
 
+                # copy assets, which can be files or folders and are just copied to the container
+                elif self.parameters[key]['type'] == 'asset':
+                    # try to copy directory
+                    try:
+                        dirname = os.path.basename(os.path.normpath(value))
+                        shutil.copytree(value, os.path.join(path, dirname), dirs_exist_ok=False)
+                        value = f"/in/{dirname}"
+                    # if copying directory fails, copy file
+                    except Exception as e1:
+                        try:
+                            fname = f"{key}{os.path.splitext(value)[1]}"
+                            shutil.copy(value, os.path.join(path, fname))
+                            value = f"/in/{fname}"
+                        # if copying the file also fails, raise both exceptions
+                        except Exception as e2:
+                            raise e1 from e2
             # add
             params[key] = value
         

--- a/toolbox_runner/tool.py
+++ b/toolbox_runner/tool.py
@@ -317,12 +317,14 @@ class Tool:
                         dirname = os.path.basename(os.path.normpath(value))
                         shutil.copytree(value, os.path.join(path, dirname), dirs_exist_ok=False)
                         value = f"/in/{dirname}"
+                        
                     # if copying directory fails, copy file
                     except Exception as e1:
                         try:
                             fname = f"{key}{os.path.splitext(value)[1]}"
                             shutil.copy(value, os.path.join(path, fname))
                             value = f"/in/{fname}"
+                            
                         # if copying the file also fails, raise both exceptions
                         except Exception as e2:
                             raise e1 from e2


### PR DESCRIPTION
This Pull Request introduces the new parameter type `asset` to the tool-runner.

Assets can be files or folders, that are just copied into the tool container.
In contrast to the type `file`, assets are never converted into a programming language-specific representation (e.g. csv files as pandas dataframes).

I think that we do not have to change anything in the `json2args` packages, as the value of parameters of type `asset` are just returned as a string (path to the file), which also works at the moment.

We just have to think about if we want to limit the type `file` to structures / data, that have a representation in the different programming languages and never just copy `file`s into the tool container. To implement this, we would basically just need to delete these lines of code:
https://github.com/hydrocode-de/tool-runner/blob/6b99aff113a2f52ed2eeb8b3ee0cc17346eb1719/toolbox_runner/tool.py#L306-L311 